### PR TITLE
Add backend scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Environment variables for AarogyaAI
+OPENAI_API_KEY=your_openai_key
+MONGODB_URI=your_mongodb_uri
+RAZORPAY_KEY_ID=your_razorpay_key
+RAZORPAY_KEY_SECRET=your_razorpay_secret
+RAZORPAY_WEBHOOK_SECRET=your_webhook_secret
+BOT_NAME=AarogyaAI

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,81 @@
+Prompt for Codex to develop a conversational AI healthcare assistant named 'AarogyaAI'.
+
+AarogyaAI is a multilingual, conversational health assistant designed for Tier 2 and Tier 3 Indian populations. It provides symptom triage, wellness guidance, supplement recommendations, lab test suggestions, and escalates to an RMP for appropriate conditions, while complying with India's Telemedicine Practice Guidelines 2020 and DPDP Act.
+
+This chatbot is built using Python (FastAPI backend), hosted on Render, connected to a MongoDB Atlas instance, and uses ChatGPT (GPT-4) API as the conversational engine.
+
+=== OBJECTIVE ===
+Build a secure, user-friendly WhatsApp-like chatbot interface that:
+- Uses a conversational flow (not form-based)
+- Performs basic symptom triage
+- Gives wellness/supplement suggestions (AI-only scope)
+- Connects to human RMPs when needed
+- Saves data to MongoDB
+- Summarizes chat for doctors
+- Initiates Razorpay payment link for consultations
+
+=== FEATURES ===
+
+1. START CHAT FLOW:
+Greet user → Ask for consent → Collect basic demographic info (name, age, gender, location)
+Use conversational tone and confirm each input with natural follow-up.
+
+2. TRIAGE:
+Detect common symptoms using GPT-4 → Guide user using symptom checklists → AI gives general advice if low risk
+If red flags found, escalate to RMP (doctor).
+
+3. AI SERVICES (as per Healthcare Services Scope):
+- General health education
+- Nutrition & lifestyle guidance
+- Mental wellness screening
+- Supplement suggestions
+- Triage and referral to specialist (via text)
+AI will never diagnose or prescribe medications.
+
+4. ESCALATION:
+If medical consult needed:
+- Offer WhatsApp/audio consult → Razorpay ₹99 payment link
+- Offer video consult → Razorpay ₹249 payment link (15 min)
+
+5. DATABASE INTEGRATION (MongoDB):
+- Store user profile, chat history, symptoms, suggestions, consent, and timestamps
+- On RMP escalation: summarize chat + export to structured format (e.g., JSON) and save to MongoDB with consult status
+- Enable doctor to query past history via patient phone number
+
+6. INPUT VALIDATION:
+Use regex or NLP for basic validation (e.g., age must be number < 120, valid PIN code, name not empty)
+Use fallback clarifying messages in case of ambiguous inputs
+
+7. SECURITY & COMPLIANCE:
+- Follow DPDP Act: store only necessary data with user consent
+- Add opt-out and data erasure option
+- Show privacy policy link at start
+
+=== SAMPLE CONVERSATION SNIPPET ===
+User: "Hello"
+Bot: "Namaste 👏 I’m AarogyaAI, your health buddy. I can give health tips, guide you on symptoms, and connect you to a doctor if needed. Do you agree to share your health info so I can help you better? (Yes/No)"
+
+User: "Yes"
+Bot: "Great! Let’s begin. What’s your name?"
+...
+Bot: "Thanks, Ramesh. I’ll remember that. What health issue are you facing today?"
+
+...
+Bot: "From your answers, it seems you might be experiencing mild acidity. Here are some home tips. Would you like to speak with a doctor just to be safe?"
+
+User: "Yes, video call."
+Bot: "Got it. Please complete your ₹249 payment using this link: https://razorpay.com/pay/video249. Once done, I’ll connect you."
+
+=== DEPLOYMENT ===
+- Backend: FastAPI
+- AI: OpenAI GPT-4 API
+- Hosting: Render
+- Database: MongoDB Atlas
+- Payments: Razorpay links (WhatsApp/audio: ₹99; video: ₹249)
+
+=== ADDITIONAL ===
+- Include basic analytics (no. of users, triage outcomes, consults booked)
+- Multilingual support with fallback to English (Hindi default)
+- Support voice-to-text in future version
+
+END PROMPT.

--- a/README.md
+++ b/README.md
@@ -105,5 +105,10 @@ Email us at [contact@aarogyaai.in](mailto:contact@aarogyaai.in)
 
 ---
 
+## 📜 Prompt Specification
+For the complete design prompt guiding AarogyaAI's features and compliance goals, see [PROMPT.md](PROMPT.md).
+
+---
+
 ## 🏁 License
 MIT License

--- a/chat_engine.py
+++ b/chat_engine.py
@@ -1,0 +1,31 @@
+"""OpenAI GPT-4 integration for AarogyaAI."""
+
+import os
+from typing import List, Dict
+
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+SYSTEM_PROMPT = (
+    "You are AarogyaAI, an assistive health chatbot. "
+    "Provide general health education and symptom triage. "
+    "Never prescribe medication. Escalate to an RMP when red flags appear."
+)
+
+async def generate_response(messages: List[Dict[str, str]]) -> str:
+    """Call OpenAI's API and return the assistant's reply."""
+    if not openai.api_key:
+        return "AI service unavailable."
+
+    chat_messages = [{"role": "system", "content": SYSTEM_PROMPT}] + messages
+    try:
+        resp = await openai.ChatCompletion.acreate(
+            model="gpt-4",
+            messages=chat_messages,
+            temperature=0.6,
+        )
+        return resp.choices[0].message["content"].strip()
+    except Exception:
+        return "Sorry, I couldn't process that right now."
+

--- a/db.py
+++ b/db.py
@@ -1,0 +1,26 @@
+"""MongoDB integration using Motor."""
+
+import os
+from typing import Any, Dict
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+MONGODB_URI = os.getenv("MONGODB_URI")
+client = AsyncIOMotorClient(MONGODB_URI)
+db = client.get_default_database()
+
+async def save_user(user: Dict[str, Any]) -> str:
+    res = await db.users.insert_one(user)
+    return str(res.inserted_id)
+
+async def save_chat(chat: Dict[str, Any]) -> str:
+    res = await db.chats.insert_one(chat)
+    return str(res.inserted_id)
+
+async def save_summary(summary: Dict[str, Any]) -> str:
+    res = await db.summaries.insert_one(summary)
+    return str(res.inserted_id)
+
+async def get_user_by_phone(phone: str) -> Dict[str, Any] | None:
+    return await db.users.find_one({"phone": phone})
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from routes import router
+
+app = FastAPI(title="AarogyaAI")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(router)
+

--- a/razorpay_utils.py
+++ b/razorpay_utils.py
@@ -1,0 +1,30 @@
+"""Razorpay integration for payment links."""
+
+import os
+from typing import Dict
+
+import razorpay
+
+CLIENT = razorpay.Client(
+    auth=(os.getenv("RAZORPAY_KEY_ID"), os.getenv("RAZORPAY_KEY_SECRET"))
+)
+
+async def create_payment_link(amount: int, description: str) -> str:
+    data = {
+        "amount": amount * 100,  # Razorpay accepts paise
+        "currency": "INR",
+        "description": description,
+    }
+    link = CLIENT.payment_link.create(data)
+    return link.get("short_url")
+
+
+def verify_signature(body: bytes, signature: str) -> bool:
+    try:
+        razorpay.Utility.verify_webhook_signature(
+            body, signature, os.getenv("RAZORPAY_WEBHOOK_SECRET")
+        )
+        return True
+    except razorpay.errors.SignatureVerificationError:
+        return False
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+motor
+openai
+pydantic
+python-dotenv
+razorpay

--- a/routes.py
+++ b/routes.py
@@ -1,0 +1,53 @@
+"""API endpoints for AarogyaAI."""
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from chat_engine import generate_response
+from db import save_user, save_chat, save_summary
+from schemas import Consent, UserInfo, SymptomData, Summary, PaymentWebhook
+from utils import timestamp
+from razorpay_utils import create_payment_link, verify_signature
+
+router = APIRouter()
+
+
+@router.post("/start")
+async def start_chat(consent: Consent, user: UserInfo):
+    if not consent.accepted:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Consent required")
+    user_dict = user.dict()
+    user_dict["consent_time"] = consent.timestamp
+    await save_user(user_dict)
+    return {"message": f"Welcome {user.name}! How can I help you today?"}
+
+
+@router.post("/triage")
+async def triage(symptom: SymptomData):
+    messages = [{"role": "user", "content": symptom.description}]
+    reply = await generate_response(messages)
+    await save_chat({"input": symptom.description, "output": reply, "time": timestamp()})
+    return {"reply": reply}
+
+
+@router.post("/consult")
+async def consult(request: UserInfo):
+    link = await create_payment_link(99, "AarogyaAI Consult")
+    return {"payment_link": link}
+
+
+@router.post("/summary")
+async def store_summary(summary: Summary):
+    await save_summary(summary.dict())
+    return {"status": "saved"}
+
+
+@router.post("/payment-webhook")
+async def payment_webhook(request: Request):
+    signature = request.headers.get("X-Razorpay-Signature")
+    body = await request.body()
+    if not verify_signature(body, signature or ""):
+        raise HTTPException(status_code=400, detail="Invalid signature")
+    payload = await request.json()
+    await save_chat({"payment_event": payload, "time": timestamp()})
+    return {"status": "ok"}
+

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,39 @@
+"""Pydantic models for AarogyaAI."""
+
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class Consent(BaseModel):
+    accepted: bool
+    timestamp: str
+
+
+class UserInfo(BaseModel):
+    name: str
+    age: int
+    gender: str
+    location: str
+    phone: Optional[str] = None
+
+
+class SymptomData(BaseModel):
+    description: str
+    duration: Optional[str] = None
+    severity: Optional[str] = None
+
+
+class ConsultRequest(BaseModel):
+    user: UserInfo
+    symptoms: SymptomData
+
+
+class Summary(BaseModel):
+    user_phone: Optional[str]
+    summary: str
+    consult_id: Optional[str] = None
+
+
+class PaymentWebhook(BaseModel):
+    payload: dict
+

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,20 @@
+"""Utility helpers for AarogyaAI."""
+
+import re
+from datetime import datetime
+
+AGE_PATTERN = re.compile(r"^\d{1,3}$")
+PIN_PATTERN = re.compile(r"^\d{6}$")
+
+
+def validate_age(age: str) -> bool:
+    return AGE_PATTERN.match(age) is not None and 0 < int(age) <= 120
+
+
+def validate_pin(pin: str) -> bool:
+    return PIN_PATTERN.match(pin) is not None
+
+
+def timestamp() -> str:
+    return datetime.utcnow().isoformat()
+


### PR DESCRIPTION
## Summary
- implement FastAPI server and routes
- add GPT-4 chat engine and Mongo helpers
- integrate Razorpay and validation utilities
- provide example environment and Dockerfile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cf663fde883269ae0c5bc4746de5f