### PR TITLE
Add DB name fallback and doc updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Environment variables for AarogyaAI
 OPENAI_API_KEY=your_openai_key
-MONGODB_URI=your_mongodb_uri
+MONGODB_URI=your_mongodb_uri # e.g. mongodb+srv://user:pass@cluster/dbname
+MONGODB_DB_NAME=your_db_name
 RAZORPAY_KEY_ID=your_razorpay_key
 RAZORPAY_KEY_SECRET=your_razorpay_secret
 RAZORPAY_WEBHOOK_SECRET=your_webhook_secret

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ cd aarogyaai
 Create a `.env` file with the following:
 ```env
 OPENAI_API_KEY=your_openai_key
-MONGODB_URI=your_mongodb_connection_string
+MONGODB_URI=your_mongodb_connection_string  # include DB name, e.g. mongodb+srv://user:pass@host/dbname
+MONGODB_DB_NAME=your_db_name
 RAZORPAY_KEY_ID=your_key_id
 RAZORPAY_KEY_SECRET=your_key_secret
 BOT_NAME=AarogyaAI

--- a/db.py
+++ b/db.py
@@ -4,10 +4,20 @@ import os
 from typing import Any, Dict
 
 from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo.errors import ConfigurationError
 
 MONGODB_URI = os.getenv("MONGODB_URI")
 client = AsyncIOMotorClient(MONGODB_URI)
-db = client.get_default_database()
+
+try:
+    db = client.get_default_database()
+except ConfigurationError:
+    db_name = os.getenv("MONGODB_DB_NAME")
+    if not db_name:
+        raise RuntimeError(
+            "MONGODB_DB_NAME not set and database name missing from MONGODB_URI"
+        )
+    db = client[db_name]
 
 async def save_user(user: Dict[str, Any]) -> str:
     res = await db.users.insert_one(user)


### PR DESCRIPTION
## Summary
- support `MONGODB_DB_NAME` fallback when no DB is present in the MongoDB URI
- document `MONGODB_DB_NAME` in README and .env.example

## Testing
- `python -m py_compile db.py`


------
https://chatgpt.com/codex/tasks/task_e_685d0e4274788326ba9aaa486d700b70