### PR TITLE
Add StartPayload model

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
+### Example request to `/start`
+```json
+{
+  "consent": {"accepted": true, "timestamp": "2024-01-01T12:00:00Z"},
+  "user": {
+    "name": "Asha",
+    "age": 28,
+    "gender": "F",
+    "location": "Pune",
+    "phone": "9876543210"
+  }
+}
+```
+
 ---
 
 ## 💬 Chatbot Workflow

--- a/routes.py
+++ b/routes.py
@@ -4,7 +4,13 @@ from fastapi import APIRouter, HTTPException, Request, status
 
 from chat_engine import generate_response
 from db import save_user, save_chat, save_summary
-from schemas import Consent, UserInfo, SymptomData, Summary, PaymentWebhook
+from schemas import (
+    StartPayload,
+    UserInfo,
+    SymptomData,
+    Summary,
+    PaymentWebhook,
+)
 from utils import timestamp
 from razorpay_utils import create_payment_link, verify_signature
 
@@ -12,9 +18,13 @@ router = APIRouter()
 
 
 @router.post("/start")
-async def start_chat(consent: Consent, user: UserInfo):
+async def start_chat(payload: StartPayload):
+    consent = payload.consent
+    user = payload.user
     if not consent.accepted:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Consent required")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Consent required"
+        )
     user_dict = user.dict()
     user_dict["consent_time"] = consent.timestamp
     await save_user(user_dict)

--- a/schemas.py
+++ b/schemas.py
@@ -17,6 +17,13 @@ class UserInfo(BaseModel):
     phone: Optional[str] = None
 
 
+class StartPayload(BaseModel):
+    """Payload for the `/start` route combining consent and user info."""
+
+    consent: Consent
+    user: UserInfo
+
+
 class SymptomData(BaseModel):
     description: str
     duration: Optional[str] = None


### PR DESCRIPTION
## Summary
- add `StartPayload` model combining consent and user info
- update `/start` route to use the new model
- document start endpoint payload in README

## Testing
- `python -m py_compile schemas.py routes.py main.py chat_engine.py db.py razorpay_utils.py utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0e6989a883268a7f889555a502f9