### PR TITLE
Add pytest app import test

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
+### 5. Run tests
+```bash
+pytest
+```
+
 ---
 
 ## 💬 Chatbot Workflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai
 pydantic
 python-dotenv
 razorpay
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+from main import app
+
+
+def test_app_import():
+    client = TestClient(app)
+    response = client.get("/docs")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add a very small pytest that imports the FastAPI app and checks the docs route
- include pytest in requirements
- document test execution in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d0e719b9083269f65b664ea8a50f8